### PR TITLE
chore(package): add repository to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "dev",
     "debug"
   ],
+  "repository": "bobbor/babel-plugin-debug",
   "author": "Philipp Paul<philipp.paul@deliveryhero.at>",
   "devDependencies": {
     "babel-core": "^6.17.0",


### PR DESCRIPTION
This info is used to look up which repository the code lives in if you find it on [npm](https://npm.im/babel-plugin-debug) or [yarn](https://yarn.pm/babel-plugin-debug)